### PR TITLE
Add the ability to produce keyed messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea
 *.iml
+/.project
+/.classpath
+/.settings

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-producer</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
+++ b/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
@@ -1,6 +1,7 @@
 package com.ft.messagequeueproducer;
 
 import com.ft.messagequeueproducer.health.QueueProxyHealthcheck;
+import com.ft.messagequeueproducer.model.KeyedMessage;
 import com.ft.messagequeueproducer.model.MessageRecord;
 import com.ft.messagequeueproducer.model.MessageWithRecords;
 import com.ft.messaging.standards.message.v1.Message;
@@ -24,8 +25,7 @@ public class QueueProxyProducer implements MessageProducer {
     @Override
     public void send(final List<Message> messages) {
         final List<MessageRecord> records = messages.stream()
-                .map(Message::toStringFull)
-                .map(s -> new MessageRecord(s.getBytes(UTF8)))
+            .map(msg -> createMessageRecord(msg))
                 .collect(Collectors.toList());
         final MessageWithRecords messageWithRecords =
                 new MessageWithRecords(records);
@@ -40,6 +40,16 @@ public class QueueProxyProducer implements MessageProducer {
         }
     }
 
+    private MessageRecord createMessageRecord(Message message) {
+      String key = "";
+      if (message instanceof KeyedMessage) {
+        key = ((KeyedMessage)message).getKey();
+      }
+      
+      String txt = message.toStringFull();
+      return new MessageRecord(key.getBytes(UTF8), txt.getBytes(UTF8));
+    }
+    
     public static JerseyClientNeeded builder() {
         return new Builder();
     }

--- a/src/main/java/com/ft/messagequeueproducer/model/KeyedMessage.java
+++ b/src/main/java/com/ft/messagequeueproducer/model/KeyedMessage.java
@@ -1,0 +1,52 @@
+package com.ft.messagequeueproducer.model;
+
+import java.util.UUID;
+
+import com.ft.messaging.standards.message.v1.Message;
+import com.ft.platform.hostinfo.HostLocation;
+import com.ft.platform.hostinfo.HostName;
+
+public class KeyedMessage extends Message {
+  private String key;
+  
+  public static KeyedMessage forMessageAndKey(Message in, String key) {
+    KeyedMessage out = new KeyedMessage();
+    
+    out.setMessageId(in.getMessageId());
+    out.setMessageTimestamp(in.getMessageTimestamp());
+    out.setMessageType(in.getMessageType());
+    
+    UUID correlationId = in.getCorrelationId();
+    if (correlationId != null) {
+      out.setCorrelationId(correlationId);
+    }
+    
+    out.setOriginSystemId(in.getOriginSystemId());
+    
+    HostLocation originHostLocation = in.getOriginHostLocation();
+    if (originHostLocation != null) {
+      out.setOriginHostLocation(originHostLocation);
+    }
+    
+    HostName originHost = in.getOriginHost();
+    if (originHost != null) {
+      out.setOriginHost(originHost);
+    }
+    
+    out.setContentType(in.getContentType());
+    
+    in.getCustomMessageHeaders().forEach(out::addCustomMessageHeader);
+    
+    out.setMessageBody(in.getMessageBody());
+    
+    out.key = key;
+    
+    return out;
+  }
+  
+  private KeyedMessage() {/* only instantiable with forMessageAndKey method */}
+  
+  public String getKey() {
+    return key;
+  }
+}

--- a/src/main/java/com/ft/messagequeueproducer/model/MessageRecord.java
+++ b/src/main/java/com/ft/messagequeueproducer/model/MessageRecord.java
@@ -1,17 +1,24 @@
 package com.ft.messagequeueproducer.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MessageRecord {
-
+    private final byte[] key;
     private final byte[] value;
 
-    public MessageRecord(@JsonProperty("value") byte[] value) {
+    public MessageRecord(@JsonProperty("key") byte[] key, @JsonProperty("value") byte[] value) {
+        this.key = key;
         this.value = value;
     }
-
+    
+    public byte[] getKey() {
+        return key;
+    }
+    
     public byte[] getValue() {
         return value;
     }

--- a/src/test/java/com/ft/messagequeueproducer/QueueProxyProducerTest.java
+++ b/src/test/java/com/ft/messagequeueproducer/QueueProxyProducerTest.java
@@ -1,21 +1,33 @@
 package com.ft.messagequeueproducer;
 
+import com.ft.messagequeueproducer.model.KeyedMessage;
+import com.ft.messagequeueproducer.model.MessageRecord;
 import com.ft.messagequeueproducer.model.MessageWithRecords;
 import com.ft.messaging.standards.message.v1.Message;
+import com.ft.messaging.standards.message.v1.MessageParser;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.anyOf;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -37,20 +49,51 @@ public class QueueProxyProducerTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private QueueProxyService mockedService;
+    @InjectMocks
+    private QueueProxyProducer producer;
 
     @Test
     public void testHappyProducing() {
-        final QueueProxyService mockedService = mock(QueueProxyService.class);
-        final QueueProxyProducer producer = new QueueProxyProducer(mockedService);
-
         producer.send(MESSAGES);
-        verify(mockedService).send(any(MessageWithRecords.class));
+        
+        ArgumentCaptor<MessageWithRecords> c = ArgumentCaptor.forClass(MessageWithRecords.class);
+        verify(mockedService).send(c.capture());
+        
+        MessageWithRecords actual = c.getValue();
+        List<MessageRecord> records = actual.getRecords();
+        assertThat(records.size(), equalTo(2));
+        
+        MessageRecord sent = records.get(0);
+        assertThat(sent.getKey(), anyOf(nullValue(), equalTo(new byte[0])));
+        assertThat(MessageParser.parse(sent.getValue()).toStringFull(), equalTo(MESSAGES.get(0).toStringFull()));
+        
+        sent = records.get(1);
+        assertThat(sent.getKey(), anyOf(nullValue(), equalTo(new byte[0])));
+        assertThat(MessageParser.parse(sent.getValue()).toStringFull(), equalTo(MESSAGES.get(1).toStringFull()));
+    }
+
+    @Test
+    public void thatMessageKeyIsUsed() {
+      String key = UUID.randomUUID().toString();
+      KeyedMessage msg = KeyedMessage.forMessageAndKey(MESSAGES.get(0), key);
+      producer.send(Collections.singletonList(msg));
+      
+      ArgumentCaptor<MessageWithRecords> c = ArgumentCaptor.forClass(MessageWithRecords.class);
+      verify(mockedService).send(c.capture());
+      
+      MessageWithRecords actual = c.getValue();
+      List<MessageRecord> records = actual.getRecords();
+      assertThat(records.size(), equalTo(1));
+      
+      MessageRecord sent = records.get(0);
+      assertThat(new String(sent.getKey(), UTF_8), equalTo(key));
+      assertThat(MessageParser.parse(sent.getValue()).toStringFull(), equalTo(MESSAGES.get(0).toStringFull()));
     }
 
     @Test
     public void testExceptionIfHttpExceptionStatus() {
-        final QueueProxyService mockedService = mock(QueueProxyService.class);
-        final QueueProxyProducer producer = new QueueProxyProducer(mockedService);
         doThrow(new QueueProxyServiceException("couldn't request", new RuntimeException("no")))
                 .when(mockedService).send(any(MessageWithRecords.class));
         thrown.expect(QueueProxyProducerException.class);

--- a/src/test/java/com/ft/messagequeueproducer/QueueProxyServiceTest.java
+++ b/src/test/java/com/ft/messagequeueproducer/QueueProxyServiceTest.java
@@ -35,7 +35,7 @@ public class QueueProxyServiceTest {
         for (byte i = 0; i < 2; i++) {
             byte[] arr = new byte[1];
             arr[0] = i;
-            final MessageRecord record = new MessageRecord(arr);
+            final MessageRecord record = new MessageRecord(null, arr);
             RECORDS.add(record);
         }
     }}


### PR DESCRIPTION
Do I need to bump the version in the POM file manually?

If the client presents a KeyedMessage, use the key when constructing the
message to sent to Kafka. This can be used to control to which partition
a message will be sent. (All messages with the same key will be sent to
the same partition and will therefore be consumed in the order in which
they were produced).
