### PR TITLE
Accept an empty list and do nothing with it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-producer</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
+++ b/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
@@ -24,6 +24,10 @@ public class QueueProxyProducer implements MessageProducer {
 
     @Override
     public void send(final List<Message> messages) {
+      if (messages.isEmpty()) {
+        return; // do nothing
+      }
+      
         final List<MessageRecord> records = messages.stream()
             .map(msg -> createMessageRecord(msg))
                 .collect(Collectors.toList());

--- a/src/test/java/com/ft/messagequeueproducer/QueueProxyProducerTest.java
+++ b/src/test/java/com/ft/messagequeueproducer/QueueProxyProducerTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueueProxyProducerTest {
@@ -99,5 +100,12 @@ public class QueueProxyProducerTest {
         thrown.expect(QueueProxyProducerException.class);
 
         producer.send(MESSAGES);
+    }
+
+    @Test
+    public void thatEmptyListIsAcceptedButSendsNoRequestsToProxy() {
+        producer.send(Collections.emptyList());
+        
+        verifyZeroInteractions(mockedService);
     }
 }


### PR DESCRIPTION
The Kafka proxy returns a 422 (unprocessable entity) error if an empty
list is submitted to it.
