### PR TITLE
Add support for Jersey 2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,20 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-producer</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.23.2</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>1.18.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/ft/messagequeueproducer/Jersey2Client.java
+++ b/src/main/java/com/ft/messagequeueproducer/Jersey2Client.java
@@ -1,0 +1,81 @@
+package com.ft.messagequeueproducer;
+
+import com.ft.messagequeueproducer.model.MessageWithRecords;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+public class Jersey2Client implements HttpClient {
+
+    private static final String JSON = "application/json";
+
+    private final Client queueProxyClient;
+
+    public Jersey2Client(final Client queueProxyClient) {
+        this.queueProxyClient = queueProxyClient;
+    }
+
+    @Override
+    public HttpResponse get(final URI uri, final Optional<Map<String, String>> additionalHeaders) {
+        Response response = null;
+        try {
+            final WebTarget webResource = queueProxyClient.target(uri);
+            Invocation.Builder builder = webResource.request();
+            if (additionalHeaders.isPresent()) {
+                for (final Map.Entry<String, String> entry : additionalHeaders.get().entrySet()) {
+                    builder = builder.header(entry.getKey(), entry.getValue());
+                }
+            }
+            
+            response = builder.buildGet().invoke(Response.class);
+            
+            return new HttpResponse(response.getStatus(), response.readEntity(String.class));
+        } catch (ProcessingException ex) {
+            throw new HttpClientException("Jersey client throwing exception.", ex);
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    @Override
+    public HttpResponse post(final URI uri, final MessageWithRecords messageWithRecords,
+            final Optional<Map<String, String>> additionalHeaders) {
+        Response response = null;
+        try {
+            final WebTarget webResource = queueProxyClient.target(uri);
+            Invocation.Builder builder = webResource.request(JSON);
+            if (additionalHeaders.isPresent()) {
+                for (final Map.Entry<String, String> entry : additionalHeaders.get().entrySet()) {
+                    builder = builder.header(entry.getKey(), entry.getValue());
+                }
+            }
+            
+            response = builder.buildPost(Entity.entity(messageWithRecords, JSON)).invoke(Response.class);
+            return new HttpResponse(response.getStatus(), response.readEntity(String.class));
+        } catch (final ProcessingException ex) {
+            throw new HttpClientException("Jersey client throwing exception.", ex);
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    @Override
+    public URI buildURI(final QueueProxyConfiguration queueProxyConfiguration) {
+        return UriBuilder.fromUri("http://" + queueProxyConfiguration.getProxyHostAndPort())
+                .path("topics")
+                .path(queueProxyConfiguration.getTopicName())
+                .build();
+    }
+}

--- a/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
+++ b/src/main/java/com/ft/messagequeueproducer/QueueProxyProducer.java
@@ -54,7 +54,7 @@ public class QueueProxyProducer implements MessageProducer {
       return new MessageRecord(key.getBytes(UTF8), txt.getBytes(UTF8));
     }
     
-    public static JerseyClientNeeded builder() {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -72,6 +72,11 @@ public class QueueProxyProducer implements MessageProducer {
         @Override
         public ConfigurationNeeded withJerseyClient(final Client jerseyClient) {
             this.httpClient = new JerseyClient(jerseyClient);
+            return this;
+        }
+
+        public ConfigurationNeeded withJersey2Client(final javax.ws.rs.client.Client jerseyClient) {
+            this.httpClient = new Jersey2Client(jerseyClient);
             return this;
         }
 


### PR DESCRIPTION
The order of the Jersey 1 and Jersey 2 dependencies in the POM file is
significant. Both are listed with "provided" scope. The client must
include the appropriate Jersey runtime in its own dependencies list.
